### PR TITLE
triggers a Job to run an immediate initial sync

### DIFF
--- a/artifacts/examples/example-apprepo.yaml
+++ b/artifacts/examples/example-apprepo.yaml
@@ -3,5 +3,5 @@ kind: AppRepository
 metadata:
   name: stable
 spec:
-  url: https://charts.bitnami.com
+  url: https://charts.bitnami.com/incubator
   type: helm


### PR DESCRIPTION
Previously we were just creating a CronJob, but this would only run when
the schedule is met. Until we can manually trigger a CronJob (on the
roadmap), we will need to manually create the Job.